### PR TITLE
Only run commands if they are present.

### DIFF
--- a/facets/php/composer-show
+++ b/facets/php/composer-show
@@ -1,2 +1,7 @@
 #!/bin/bash
-composer show
+
+if hash composer 2>/dev/null; then
+    composer show
+fi
+
+

--- a/facets/php/composer-version
+++ b/facets/php/composer-version
@@ -1,2 +1,5 @@
 #!/bin/bash
-composer --version
+if hash composer 2>/dev/null; then
+  composer --version
+fi
+

--- a/facets/php/php-version
+++ b/facets/php/php-version
@@ -1,2 +1,5 @@
 #!/bin/bash
-php --version
+if hash php 2>/dev/null; then
+  php --version
+fi
+


### PR DESCRIPTION
This fixes running of `composer` for when user doesn't even have it installed. 

Q1) ...but is this how we want to handle it, and other cases of uninstalled programs? Should missing commands
be handled up in the python code, e.g. looking at error codes and testing
if `stderr ~= "-bash: composer: command not found"`?

Q2) What should the facet return when program isn't even installed? A message? Empty string? Ignore the facet? 

@werg what do you think? 

existance-testing code from: https://stackoverflow.com/questions/592620/how-to-check-if-a-program-exists-from-a-bash-script