### PR TITLE
Stan/diff viewer clean

### DIFF
--- a/bin/diffenv-nopaging
+++ b/bin/diffenv-nopaging
@@ -93,11 +93,12 @@ elif args.compare is not None:
     local_env = main.collect_env(facets, whitelist)
     compare_env = main.read_file_or_url(args.compare)
     try:
-        diffviewer.display_diff(local_env,
+        diff = diffviewer.diff(local_env,
                                 compare_env,
-                                outfilestream,
                                 not args.no_color)
+        outfilestream.writelines(diff)
     except BrokenPipeError as e:
+        # TODO (Gabe) : We should comment why we ignore this error.
         pass
 
 elif args.share:

--- a/diffenv/diffviewer.py
+++ b/diffenv/diffviewer.py
@@ -22,9 +22,9 @@ B_MARKER_TXT = '++>'
 def diff(fromfile, tofile, do_color:bool):
     """
     Primary funciton. Display diff between two YAML files.
-    fromFile: YAML structrue
-    toFile: YAML structrue
-    doColor: Boolean indicating whether to colorize output
+    fromfile: YAML structrue
+    tofile: YAML structrue
+    do_color: Boolean indicating whether to colorize output
     """
     buf = StringIO()
     yaml.dump(diff_nested(fromfile, tofile), buf)

--- a/diffenv/diffviewer.py
+++ b/diffenv/diffviewer.py
@@ -82,7 +82,7 @@ def colorize_diff(diff: typing.List[str]):
 
 def diff_nested(m1, m2):
     """
-    Computes diff of two nested YAML structures.
+    Recursively computes diff of two nested YAML structures.
     Note m1, m2 may also be strings
     """
     if isinstance(m1, str) or type(m1) != type(m2):


### PR DESCRIPTION
- Documented the types expected for some functions
- Clarified what primary function is
- Made more sense for filestreams to be handled elsewhere--no need for diff module to know about that

@werg : Am I right that it only outputs lines that are _different_ between the two inputs? Also, would like more documentation around recursive functions, as they do not self-document well!
