### PR TITLE
Allow users to edit env file before sharing.

### DIFF
--- a/bin/diffenv-nopaging
+++ b/bin/diffenv-nopaging
@@ -8,7 +8,7 @@ import requests
 from io import StringIO
 from signal import signal, SIGPIPE, SIG_DFL
 
-from diffenv import main, diffviewer
+from diffenv import main, diffviewer, editor
 
 # Handle arguments
 parser = argparse.ArgumentParser(
@@ -105,12 +105,15 @@ elif args.share:
     # --share : Get a shareable link
     sys.stderr.write("Collecting env...\r")
     env = main.collect_env(facets, whitelist)
-    buf = StringIO()
-    main.yaml.dump(env, buf)
+    yaml_stream = StringIO()
+    main.yaml.dump(env, yaml_stream)
+
+    env_string = editor.raw_input_editor(default=yaml_stream.getvalue())
+
     upload_url = args.post
     sys.stderr.write("\033[K")
     sys.stderr.write("Uploading...\r")
-    r = requests.post(upload_url, files={'env.yaml': buf.getvalue()})
+    r = requests.post(upload_url, files={'env.yaml': env_string})
     sys.stderr.write("\033[K")
     print('Run the following line on comparison environment:')
     print()

--- a/diffenv/editor.py
+++ b/diffenv/editor.py
@@ -1,0 +1,23 @@
+import tempfile
+import subprocess
+import os
+
+# From: https://chase-seibert.github.io/blog/2012/10/31/python-fork-exec-vim-raw-input.html
+
+def raw_input_editor(default=None, editor=None):
+    ''' like the built-in raw_input(), except that it uses a visual
+    text editor for ease of editing. Unline raw_input() it can also
+    take a default value. '''
+    with tempfile.NamedTemporaryFile(mode='r+') as tmpfile:
+        if default:
+            tmpfile.write(default)
+            tmpfile.flush()
+        subprocess.check_call([editor or get_editor(), tmpfile.name])
+        tmpfile.seek(0)
+        return tmpfile.read().strip()
+
+
+def get_editor():
+    return (os.environ.get('VISUAL')
+            or os.environ.get('EDITOR')
+            or 'vi')


### PR DESCRIPTION
Like a git commit message, allows users to edit their env file before it is uploaded. 

Do we want this?

It was pretty easy to add via this [post](https://chase-seibert.github.io/blog/2012/10/31/python-fork-exec-vim-raw-input.html). Maybe add a flag to enable/disable it. 